### PR TITLE
iOS Use native UUID function

### DIFF
--- a/unity3d/Assets/Plugins/iOS/swrve_sdk.mm
+++ b/unity3d/Assets/Plugins/iOS/swrve_sdk.mm
@@ -36,6 +36,12 @@ extern "C"
         return swrveCStringCopy([appVersion UTF8String]);
     }
 
+    char* _swrveiOSUUID()
+    {
+        NSString* swrveUUID = [[NSUUID UUID] UUIDString];
+        return swrveCStringCopy([swrveUUID UTF8String]);    
+    }
+
     void _swrveRegisterForPushNotifications() 
     {
         UIApplication* app = [UIApplication sharedApplication];

--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveSDK.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveSDK.cs
@@ -46,6 +46,9 @@ public partial class SwrveSDK
 
     [DllImport ("__Internal")]
     private static extern void _swrveRegisterForPushNotifications();
+
+    [DllImport ("__Internal")]
+    private static extern void _swrveiOSUUID();
 #endif
 
     private int gameId;

--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
@@ -544,22 +544,23 @@ public partial class SwrveSDK
 
     private string GetRandomUUID ()
     {
+#if UNITY_IPHONE
+        try {
+            return _swrveiOSUUID();
+        } catch (Exception exp) {
+            SwrveLog.LogWarning ("Couldn't get random UUID: " + exp.ToString ());
+        }
+#else
         try {
             Type type = System.Type.GetType ("System.Guid");
             if (type != null) {
-#if NETFX_CORE
-                MethodInfo methodInfo = RuntimeReflectionExtensions.GetRuntimeMethod(type, "NewGuid", new Type[0]);
-                MethodInfo stringMethodInfo = RuntimeReflectionExtensions.GetRuntimeMethod(type, "ToString", new Type[0]);
-#else
                 MethodInfo methodInfo = type.GetMethod ("NewGuid");
-                MethodInfo stringMethodInfo = type.GetMethod ("ToString", new Type[0]);
-#endif
-                if (methodInfo != null && stringMethodInfo != null) {
+                if (methodInfo != null) {
                     object result = methodInfo.Invoke (null, null);
                     if (result != null) {
-                        object stringResult = stringMethodInfo.Invoke (result, null);
-                        if (stringResult != null && stringResult is string) {
-                            return (string)stringResult;
+                        string stringResult = result.ToString();
+                        if (!string.IsNullOrEmpty(stringResult)) {
+                            return stringResult;
                         }
                     }
                 }
@@ -567,11 +568,13 @@ public partial class SwrveSDK
         } catch (Exception exp) {
             SwrveLog.LogWarning ("Couldn't get random UUID: " + exp.ToString ());
         }
+#endif
 
-        // Generate random string
-        String randomString = string.Empty;
+        // Generate random string if all fails
+        string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        string randomString = string.Empty;
         for (int i = 0; i < 128; i++) {
-            randomString += (char)UnityEngine.Random.Range (0, char.MaxValue);
+            randomString += chars[UnityEngine.Random.Range (0, chars.Length - 1)];
         }
         return randomString;
     }


### PR DESCRIPTION
Using the System.Guid.NewGuid() method crashes in iOS built with a micro mscorlib. The class is there but launches an exception that cannot be captured.

This pull request makes iOS builds use the native NSUUID for obtaining a user id and changes the fallback method to only use alphanumeric values.

(Found while upgrading SushiChop to Unity SDK 3.2)
