### PR TITLE
6578 Open custom button actions in a browser by default

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
@@ -854,9 +854,15 @@ public partial class SwrveSDK
                     SwrveLog.LogError("Install button app store url empty!");
                 }
             } else if (clickedButton.ActionType == SwrveActionType.Custom) {
+                string buttonAction = clickedButton.Action;
                 if (currentMessage.CustomButtonListener != null) {
                     // Launch custom button listener
-                    currentMessage.CustomButtonListener.OnAction (clickedButton.Action);
+                    currentMessage.CustomButtonListener.OnAction (buttonAction);
+                } else {
+                    SwrveLog.Log("No custom button listener, treating action as URL");
+                    if (!string.IsNullOrEmpty(buttonAction)) {
+                        Application.OpenURL (buttonAction);
+                    }
                 }
             }
             clickedButton.Pressed = false;


### PR DESCRIPTION
If there is no custom action button listener open the text in a browser when clicked.

https://swrvedev.jira.com/browse/SWRVE-6578
