### PR TITLE
6745 AndroidJNI.FindClass can return negative values

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
@@ -1481,7 +1481,7 @@ public partial class SwrveSDK
                 using (AndroidJavaClass unityPlayerClass = new AndroidJavaClass("com.unity3d.player.UnityPlayer")) {
                     string jniPluginClassName = SwrveAndroidPushPluginPackageName.Replace(".", "/");
 
-                    if (AndroidJNI.FindClass(jniPluginClassName).ToInt32() > 0) {
+                    if (AndroidJNI.FindClass(jniPluginClassName).ToInt32() != 0) {
                         androidPlugin = new AndroidJavaClass(SwrveAndroidPushPluginPackageName);
 
                         if (androidPlugin != null) {


### PR DESCRIPTION
https://swrvedev.jira.com/browse/SWRVE-6745

When converting the pointer to the class it can result in a negative pointer. This was causing the SDK to not register for push notifications on Android.
