### PR TITLE
6774 Filter non-alphanumeric characters in iOS push token

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/Helpers/SwrveHelper.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/Helpers/SwrveHelper.cs
@@ -19,6 +19,8 @@ public static class SwrveHelper
     // Reference to avoid this class from getting stripped
     private static System.Security.Cryptography.MD5CryptoServiceProvider fakeReference = new System.Security.Cryptography.MD5CryptoServiceProvider ();
 
+    private static Regex rgxNonAlphanumeric = new Regex("[^a-zA-Z0-9 -]");
+
     public static DateTime GetNow ()
     {
         if (Now != null && Now.HasValue) {
@@ -137,6 +139,10 @@ public static class SwrveHelper
     {
         DateTime epoch = new DateTime (1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         return epoch.AddMilliseconds (epochTime).ToString (format);
+    }
+
+    public static string FilterNonAlphanumeric(string str) {
+        return rgxNonAlphanumeric.Replace(str, string.Empty);
     }
 }
 }

--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveSDK.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveSDK.cs
@@ -1309,7 +1309,7 @@ public partial class SwrveSDK
             byte[] token = NotificationServices.deviceToken;
             if (token != null) {
                 // Send token as user update and to Babble if QA user
-                string hexToken = System.BitConverter.ToString(token).Replace("-", string.Empty);
+                string hexToken = SwrveHelper.FilterNonAlphanumeric(System.BitConverter.ToString(token));
                 bool sendDeviceInfo = (iOSdeviceToken != hexToken);
                 if (sendDeviceInfo) {
                     iOSdeviceToken = hexToken;


### PR DESCRIPTION
The iOS push token is being sent with spaces in it in some versions of Unity3D (4.3.4?).

https://swrvedev.jira.com/browse/SWRVE-6774
Private changes: https://github.com/Swrve/swrve-sdk/pull/747
