### PR TITLE
Added NULL check to SwrveResourceManager:GetResource(string)

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/ResourceManager/SwrveResourceManager.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/ResourceManager/SwrveResourceManager.cs
@@ -75,9 +75,13 @@ public class SwrveResourceManager
     /// The resource with the given unique identifier if available.
     /// </returns>
     public SwrveResource GetResource (string resourceId)
-    {
-        if (UserResources.ContainsKey (resourceId)) {
-            return UserResources [resourceId];
+    {	
+        if (UserResources != null) {
+            if (UserResources.ContainsKey (resourceId)) {
+                return UserResources [resourceId];
+            }
+        } else {
+            SwrveLog.LogWarning(String.Format("SwrveResourceManager::GetResource('{0}') Failed. 'SwrveResourceManager.UserResources' is not initialized.", resourceId));
         }
         return null;
     }


### PR DESCRIPTION
While attempting to get a resource too quickly after initializing the Swrve SDK on my iOS device I noticed the app was failing inside GetResource.  I added this code to confirm, and it was pretty help so I thought I would share it.
