### PR TITLE
7214 Null check in SwrveResourceManager

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/ResourceManager/SwrveResourceManager.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/ResourceManager/SwrveResourceManager.cs
@@ -76,8 +76,12 @@ public class SwrveResourceManager
     /// </returns>
     public SwrveResource GetResource (string resourceId)
     {
-        if (UserResources.ContainsKey (resourceId)) {
-            return UserResources [resourceId];
+        if (UserResources != null) {
+            if (UserResources.ContainsKey (resourceId)) {
+                return UserResources [resourceId];
+            }
+        } else {
+            SwrveLog.LogWarning(String.Format("SwrveResourceManager::GetResource('{0}'): Resources are not available yet.", resourceId));
         }
         return null;
     }


### PR DESCRIPTION
Original work by ChurroLoco: https://github.com/Swrve/swrve-unity-sdk/pull/21
"While attempting to get a resource too quickly after initializing the Swrve SDK on my iOS device I noticed the app was failing inside GetResource. I added this code to confirm, and it was pretty help so I thought I would share it."

https://swrvedev.jira.com/browse/SWRVE-7214

Private changes and tests: https://github.com/Swrve/swrve-sdk/pull/761
