### PR TITLE
Adding try/catch around file write operation.

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/Helpers/CrossPlatform/CrossPlatformFile.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/Helpers/CrossPlatform/CrossPlatformFile.cs
@@ -89,7 +89,11 @@ public static class CrossPlatformFile
 #else
         using (FileStream fs = File.Open(path, FileMode.Create)) {
             using (BinaryWriter binary = new BinaryWriter(fs)) {
+              try {
                 binary.Write (bytes);
+              } catch (System.Exception ex) {
+                UnityEngine.Debug.LogError (ex);
+              }
             }
         }
 #endif
@@ -103,7 +107,11 @@ public static class CrossPlatformFile
 #else
         using (FileStream fs = new FileStream(path, FileMode.Create)) {
             using (StreamWriter sw = new StreamWriter(fs)) {
+              try {
                 sw.Write (data);
+              } catch (System.Exception ex) {
+                UnityEngine.Debug.LogError (ex);
+              }
             }
         }
 #endif


### PR DESCRIPTION
## Description

Catching any exception that might happen during a write to the disk.  The stack trace below shows this can happen when the disk is full.
## Stack Trace

---

0   at System.Diagnostics.StackTrace.get_trace(System.Exception e, Int32 skipFrames, Boolean fNeedFileInfo)
1   System.IO.FileStream..ctor(System.String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean anonymous, FileOptions options)
2   System.IO.File.Open(System.String path, FileMode mode)
3   Swrve.CrossPlatformFile.SaveBytes(System.String path, System.Byte[] bytes)
4   SwrveSDK+<DownloadAsset>c__Iterator41.MoveNext()
