### PR TITLE
Crash during attempt to parse previous "SeqNum" parameter from disk.

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/Device/DeviceCarrierInfo.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/Device/DeviceCarrierInfo.cs
@@ -25,9 +25,10 @@ public class DeviceCarrierInfo : ICarrierInfo
     public DeviceCarrierInfo()
     {
         try {
-            using (AndroidJavaClass unityPlayerClass = new AndroidJavaClass("com.unity3d.player.UnityPlayer")) {
-                AndroidJavaObject context = unityPlayerClass.GetStatic<AndroidJavaObject>("currentActivity");
-                string telephonyService = "phone";
+            using (AndroidJavaClass contextClass = new AndroidJavaClass("android.content.Context"))
+            using (AndroidJavaClass unityPlayerClass = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            using (AndroidJavaObject context = unityPlayerClass.GetStatic<AndroidJavaObject>("currentActivity")) {
+                string telephonyService = contextClass.GetStatic<string>("TELEPHONY_SERVICE");
                 androidTelephonyManager = context.Call<AndroidJavaObject>("getSystemService", telephonyService);
             }
         } catch (Exception exp) {

--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
@@ -379,11 +379,9 @@ public partial class SwrveSDK
     private string getNextSeqNum ()
     {
         string seqNum = storage.Load (SeqNumSave, userId);
-        if (string.IsNullOrEmpty (seqNum)) {
-            seqNum = "0";
-        }
         // increment value
-        seqNum = (int.Parse (seqNum) + 1).ToString ();
+        int value;
+        seqNum = int.TryParse (seqNum, out value) ? (++value).ToString () : "1";
         storage.Save (SeqNumSave, seqNum, userId);
         return seqNum;
     }


### PR DESCRIPTION
- Due to I/O issues, "SeqNum" stored as text in file may be malformed, and raw parsing attempt may lead to an unrecoverable crash.
  Recently we've received a bunch of crash reports for our project, all caused by the aforementioned problem.
- A proper fix to get rid of hack used in "e77dcf956e804d3cded16af7df08bca318845c97" commit.
