### PR TITLE
7750 unity logging level

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveLog.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveLog.cs
@@ -17,7 +17,8 @@ public static class SwrveLog
         Verbose,
         Info,
         Warning,
-        Error
+        Error,
+        Disabled
     };
 
     public delegate void SwrveLogEventHandler (SwrveLog.SwrveLogType type,object message,string tag);

--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveLog.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveLog.cs
@@ -10,9 +10,11 @@ public static class SwrveLog
     /// Set to false to disable the logging produced
     /// by the Swrve SDK.
     /// </summary>
-    public static bool Verbose = true;
+
+    public static SwrveLogType LogLevel = SwrveLogType.Verbose; // Verbose by default
 
     public enum SwrveLogType {
+        Verbose,
         Info,
         Warning,
         Error
@@ -21,6 +23,10 @@ public static class SwrveLog
     public delegate void SwrveLogEventHandler (SwrveLog.SwrveLogType type,object message,string tag);
 
     public static event SwrveLogEventHandler OnLog;
+
+    public static void setLoggingLevel(SwrveLogType logType){
+        LogLevel = logType;
+    }
 
     // Default tag is "activity"
     public static void Log (object message)
@@ -40,7 +46,7 @@ public static class SwrveLog
 
     public static void Log (object message, string tag)
     {
-        if (Verbose) {
+        if (LogLevel == SwrveLogType.Verbose || LogLevel == SwrveLogType.Info || LogLevel == SwrveLogType.Warning || LogLevel == SwrveLogType.Error ) {
             Debug.Log (message);
             if (OnLog != null) {
                 OnLog (SwrveLogType.Info, message, tag);
@@ -50,7 +56,7 @@ public static class SwrveLog
 
     public static void LogWarning (object message, string tag)
     {
-        if (Verbose) {
+        if (LogLevel == SwrveLogType.Verbose || LogLevel == SwrveLogType.Warning || LogLevel == SwrveLogType.Error) {
             Debug.LogWarning (message);
             if (OnLog != null) {
                 OnLog (SwrveLogType.Warning, message, tag);
@@ -60,9 +66,11 @@ public static class SwrveLog
 
     public static void LogError (object message, string tag)
     {
-        Debug.LogError (message);
-        if (OnLog != null) {
-            OnLog (SwrveLogType.Error, message, tag);
+        if (LogLevel == SwrveLogType.Verbose || LogLevel == SwrveLogType.Error) {
+            Debug.LogError (message);
+            if (OnLog != null) {
+                OnLog (SwrveLogType.Error, message, tag);
+            }
         }
     }
 }

--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
@@ -642,7 +642,8 @@ public partial class SwrveSDK
             }
 #endif
         } else {
-            Debug.LogError("Could not append the event to the buffer. Please consider enabling SendEventsIfBufferTooLarge");
+            SwrveLog.LogError ("Could not append the event to the buffer. Please consider enabling SendEventsIfBufferTooLarge");                
+
         }
 
         if (allowShowMessage && config.TalkEnabled) {


### PR DESCRIPTION
Retargetted PR: https://github.com/Swrve/swrve-unity-sdk/pull/55

This is due for v3_6. New settable logging level for Unity SDK
Simple enough. Users have access to a static method SwrveLog.setLoggingLevel(SwrveLogType.Error)
