### PR TITLE
Fixed GetUserResourceDiff dispatching multiple callbacks on error sce…

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/SwrveSDKImp.cs
@@ -316,9 +316,8 @@ public partial class SwrveSDK
                 onError.Invoke (wwwException);
             }
         }
-
         // Launch listener
-        if (!string.IsNullOrEmpty (abTestCandidate)) {
+        else if (!string.IsNullOrEmpty (abTestCandidate)) {
             Dictionary<string, Dictionary<string, string>> userResourcesDiffNew = new Dictionary<string, Dictionary<string, string>> ();
             Dictionary<string, Dictionary<string, string>> userResourcesDiffOld = new Dictionary<string, Dictionary<string, string>> ();
             ProcessUserResourcesDiff (abTestCandidate, userResourcesDiffNew, userResourcesDiffOld);


### PR DESCRIPTION
abTestCandidate is loaded from cache in the branch above if it cannot be fetched.

This means if the above branch runs and falls through without an else, either:
1. two calls to onResult may be dispatched
2. an onError followed by onResult
