### PR TITLE
Fix for processIntent call if ADM runtime classes not found.

### DIFF
--- a/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/MainActivity.java
+++ b/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/MainActivity.java
@@ -31,12 +31,8 @@ public class MainActivity extends UnityPlayerActivity {
 
     public static void processIntent(Context context, Intent intent) {
         if (lastIntent != intent) {
-            if (SwrveAdmPushSupport.isAdmAvailable()) {
-                // Process intent that launched resumed activity
-                SwrveAdmIntentService.processIntent(context, intent);
-            } else {
-                Log.w("SwrveAdm", "SwrveAdmPushSupport not available. Is this a First Gen Kindle Fire?");
-            }
+            // Process intent that launched resumed activity
+            SwrveAdmPushSupport.processIntent(context, intent);
             lastIntent = intent;
         }
     }

--- a/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/MainActivity.java
+++ b/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/MainActivity.java
@@ -3,7 +3,6 @@ package com.swrve.unity.adm;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 
 import com.unity3d.player.UnityPlayerActivity;
 

--- a/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/MainActivity.java
+++ b/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/MainActivity.java
@@ -3,6 +3,7 @@ package com.swrve.unity.adm;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.unity3d.player.UnityPlayerActivity;
 
@@ -30,8 +31,12 @@ public class MainActivity extends UnityPlayerActivity {
 
     public static void processIntent(Context context, Intent intent) {
         if (lastIntent != intent) {
-            // Process intent that launched resumed activity
-            SwrveAdmIntentService.processIntent(context, intent);
+            if (SwrveAdmPushSupport.isAdmAvailable()) {
+                // Process intent that launched resumed activity
+                SwrveAdmIntentService.processIntent(context, intent);
+            } else {
+                Log.w("SwrveAdm", "SwrveAdmPushSupport not available. Is this a First Gen Kindle Fire?");
+            }
             lastIntent = intent;
         }
     }

--- a/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/SwrveAdmIntentService.java
+++ b/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/SwrveAdmIntentService.java
@@ -321,23 +321,5 @@ public class SwrveAdmIntentService extends ADMMessageHandlerBase {
         }
         return null;
     }
-
-    protected static void processIntent(Context context, Intent intent) {
-        if (intent == null) {
-           return;
-        }
-        try {
-            Bundle extras = intent.getExtras();
-            if (extras != null && !extras.isEmpty()) {
-                Bundle msg = extras.getBundle("notification");
-                if (msg != null) {
-                    SwrveNotification notification = SwrveNotification.Builder.build(msg);
-                    SwrveAdmPushSupport.newOpenedNotification(context, notification);
-                }
-            }
-        } catch(Exception ex) {
-            Log.e(TAG, "Could not process push notification intent", ex);
-        }
-    }
 }
 

--- a/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/SwrveAdmPushSupport.java
+++ b/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/SwrveAdmPushSupport.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.util.Log;
 
 import com.amazon.device.messaging.ADM;
@@ -196,6 +198,24 @@ public class SwrveAdmPushSupport {
                     it.remove();
                 }
             }
+        }
+    }
+
+    protected static void processIntent(Context context, Intent intent) {
+        if (intent == null) {
+            return;
+        }
+        try {
+            Bundle extras = intent.getExtras();
+            if (extras != null && !extras.isEmpty()) {
+                Bundle msg = extras.getBundle("notification");
+                if (msg != null) {
+                    SwrveNotification notification = SwrveNotification.Builder.build(msg);
+                    SwrveAdmPushSupport.newOpenedNotification(context, notification);
+                }
+            }
+        } catch(Exception ex) {
+            Log.e(TAG, "Could not process push notification intent", ex);
         }
     }
 }

--- a/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/SwrveAdmPushSupport.java
+++ b/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/SwrveAdmPushSupport.java
@@ -40,7 +40,7 @@ public class SwrveAdmPushSupport {
         return VERSION;
     }
 
-    private static boolean IsAdmAvailable() {
+    public static boolean isAdmAvailable() {
         boolean admAvailable = false;
         try {
             Class.forName("com.amazon.device.messaging.ADM");
@@ -52,7 +52,7 @@ public class SwrveAdmPushSupport {
     }
 
     public static boolean initialiseAdm(final String gameObject, final String appTitle, final String iconId, final String materialIconId, final String largeIconId, final int accentColor) {
-        if (!IsAdmAvailable()) {
+        if (!isAdmAvailable()) {
             Log.e(TAG, "Won't initialise ADM. ADM class not found.");
             return false;
         }

--- a/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/SwrveAdmPushSupport.java
+++ b/native/android/SwrveSDKPushSupport/src/amazon/java/com/swrve/unity/adm/SwrveAdmPushSupport.java
@@ -42,7 +42,7 @@ public class SwrveAdmPushSupport {
         return VERSION;
     }
 
-    public static boolean isAdmAvailable() {
+    private static boolean isAdmAvailable() {
         boolean admAvailable = false;
         try {
             Class.forName("com.amazon.device.messaging.ADM");


### PR DESCRIPTION
In Kindle Fire First Gen Devices the ADM messaging runtimes are not found. If those are not found, the SwrveAdmIntentService class doesn't link/compile properly. Calls to it cause issues. The amazon flavor MainActivity class calls into SwrvAdmIntentService.processIntent from its processIntent method - causing a crash.

Fix. The (static) processIntent implementation has been moved into the safer SwrveAdmPushSupport instead.

