### PR TITLE
[Android 12] Push Notification needs flag immutable

### DIFF
--- a/native/android/SwrveSDKPushSupport/src/main/java/com/swrve/unity/SwrvePushManagerUnityImp.java
+++ b/native/android/SwrveSDKPushSupport/src/main/java/com/swrve/unity/SwrvePushManagerUnityImp.java
@@ -6,6 +6,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.core.app.NotificationCompat;
@@ -107,6 +108,9 @@ public class SwrvePushManagerUnityImp extends SwrvePushManagerImpBase implements
     private PendingIntent createPendingIntent(Bundle msg, String activityClassName) {
         Intent intent = SwrvePushSupport.createIntent(context, msg, activityClassName);
         int id = (int) (new Date().getTime() % Integer.MAX_VALUE);
+        if(Build.VERSION.SDK_INT>=31){
+            PendingIntent.getActivity(context, id, intent, PendingIntent.FLAG_IMMUTABLE);
+        }
         return PendingIntent.getActivity(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 


### PR DESCRIPTION
With Android 12, all PendingIntent needs to have either FLAG_MUTABLE or FLAG_IMMUTABLE, otherwise, it triggers an exception. Here is the stacktrace from the error:

```
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK SwrveFirebaseMessagingService.onMessageReceived Exception
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK java.lang.IllegalArgumentException: com.org.game: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at android.app.PendingIntent.checkFlags(PendingIntent.java:382)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:465)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at android.app.PendingIntent.getActivity(PendingIntent.java:451)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at android.app.PendingIntent.getActivity(PendingIntent.java:415)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.swrve.unity.SwrvePushManagerUnityImp.createPendingIntent(SwrvePushManagerUnityImp.java:110)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.swrve.unity.SwrvePushManagerUnityImp.processNotification(SwrvePushManagerUnityImp.java:59)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.swrve.sdk.SwrvePushManagerImpBase.process(SwrvePushManagerImpBase.java:51)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.swrve.unity.SwrvePushManagerUnityImp.processMessage(SwrvePushManagerUnityImp.java:39)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.swrve.unity.firebase.SwrveFirebaseMessagingService.onMessageReceived(SwrveFirebaseMessagingService.java:27)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.google.firebase.messaging.FirebaseMessagingService.dispatchMessage(FirebaseMessagingService.java:235)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.google.firebase.messaging.FirebaseMessagingService.passMessageIntentToSdk(FirebaseMessagingService.java:185)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.google.firebase.messaging.FirebaseMessagingService.handleMessageIntent(FirebaseMessagingService.java:172)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.google.firebase.messaging.FirebaseMessagingService.handleIntent(FirebaseMessagingService.java:161)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.google.firebase.messaging.EnhancedIntentService.lambda$processIntent$0$EnhancedIntentService(EnhancedIntentService.java:78)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.google.firebase.messaging.-$$Lambda$EnhancedIntentService$NSk2h75eWhBOI4TsAFgvvtv1g9o.run(Unknown Source:6)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at com.google.android.gms.common.util.concurrent.zza.run(com.google.android.gms:play-services-basement@@18.0.0:2)
2022-11-09 16:20:34.320 10514 11334 Error SwrveSDK 	at java.lang.Thread.run(Thread.java:1012)
```
Could you implement this fix and provide a new Unity SDK? We are [required by Google](https://developer.android.com/google/play/requirements/target-sdk) to support Android 12 now.
