### PR TITLE
SIGBUS and SIGSEGV workaround

### DIFF
--- a/unity3d/Assets/Swrve/SwrveSDK/Messaging/Views/SwrveInAppMessageView.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/Messaging/Views/SwrveInAppMessageView.cs
@@ -294,11 +294,11 @@ namespace SwrveUnity.Messaging
 
         private static void UnloadAssets(SwrveWidgetView[] _widgetViews)
         {
-            for (int ii = 0; ii < _widgetViews.Length; ii++)
-            {
-                SwrveWidgetView widget = _widgetViews[ii];
-                widget.Unload();
-            }
+            // for (int ii = 0; ii < _widgetViews.Length; ii++)
+            // {
+            //     SwrveWidgetView widget = _widgetViews[ii];
+            //     widget.Unload();
+            // }
         }
 
         public IEnumerator PreloadAndDisplay(CoroutineReference<bool> wereAllLoaded)

--- a/unity3d/Assets/Swrve/SwrveSDK/Messaging/Views/SwrveWidgetView.cs
+++ b/unity3d/Assets/Swrve/SwrveSDK/Messaging/Views/SwrveWidgetView.cs
@@ -33,13 +33,18 @@ namespace SwrveUnity.Messaging
 
         public abstract void Render(float scale, int centerx, int centery, bool rotatedFormat);
 
-        public void Unload()
+        private void Unload()
         {
             if (Texture != null)
             {
                 Texture2D.Destroy(Texture);
                 Texture = null;
             }
+        }
+
+        ~SwrveWidgetView()
+        {
+            Unload();
         }
     }
 }


### PR DESCRIPTION
We noticed in our game that the `Texture2D.Destroy` method was causing memory exception crashes. Something seems to be trying to access the memory address after unity destroyed the dynamic texture. We moved the unload method to the finalizer, and the problem seems to be resolved. What could be trying to access the memory after you asked to be destroyed? Why not have the finalizer destroy the dynamic texture?